### PR TITLE
Some improvements to the rand keymap.

### DIFF
--- a/keymap.c
+++ b/keymap.c
@@ -48,7 +48,7 @@ uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 
 bool random_initialized = false;
 
-void shuffle_rand_layout() {
+void shuffle_rand_layout(void) {
     for (int i = 0; i < MATRIX_ROWS; i++) {
         for (int j = 0; j < MATRIX_COLS; j++) {
             int swap_i = rand() % MATRIX_ROWS;

--- a/keymap.c
+++ b/keymap.c
@@ -13,15 +13,61 @@ enum layers {
 enum custom_keycodes {
     QWERTY = SAFE_RANGE,
     RAND,
-    EXIT_RAND,
     QUOTE,
     NINE,
     ZERO,
-    SIGN
+    SIGN,
+    RAND_0,
+    RAND_1,
+    RAND_2,
+    RAND_3,
+    RAND_4,
+    RAND_5,
+    RAND_6,
+    RAND_7,
+    RAND_8,
+    RAND_9,
+    RAND_10,
+    RAND_11,
+    RAND_12,
+    RAND_13,
+    RAND_14,
+    RAND_15,
+    RAND_16,
+    RAND_17,
+    RAND_18,
+    RAND_19,
+    RAND_20,
+    RAND_21,
+    RAND_22,
+    RAND_23,
+    RAND_24,
+    RAND_25,
+    RAND_26,
+    RAND_27,
+    RAND_28,
+    RAND_29,
+    RAND_30,
+    RAND_31,
+    RAND_32,
+    RAND_33,
+    RAND_34,
+    RAND_35,
+    RAND_36,
+    RAND_37,
+    RAND_38,
+    RAND_39,
+    RAND_40,
+    RAND_41,
+    RAND_42,
+    RAND_43,
+    RAND_44,
+    RAND_45,
+    RAND_46
 };
 #define RAISE MO(_RAISE)
 
-uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 [_BASE] = LAYOUT_ortho_4x12(
     KC_TAB,  KC_Q,    KC_W,    KC_E,            KC_R,    KC_T,   KC_Y,  KC_U,   KC_I,           KC_O,    KC_P,    KC_BSPC,
     KC_ESC,  KC_A,    KC_S,    KC_D,            KC_F,    KC_G,   KC_H,  KC_J,   KC_K,           KC_L,    KC_SCLN, QUOTE,
@@ -38,26 +84,32 @@ uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 
 
 [_RAND] = LAYOUT_ortho_4x12(
-    KC_TAB,  KC_Q,    KC_W,    KC_E,            KC_R,    KC_T,   KC_Y,  KC_U,   KC_I,           KC_O,    KC_P,    KC_BSPC,
-    KC_ESC,  KC_A,    KC_S,    KC_D,            KC_F,    KC_G,   KC_H,  KC_J,   KC_K,           KC_L,    KC_SCLN, QUOTE,
-    KC_LEFT, KC_Z,    KC_X,    KC_C,            KC_V,    KC_B,   KC_N,  KC_M,   KC_COMM,        KC_DOT,  KC_SLSH, KC_RGHT,
-    DM_REC1, DM_PLY1, KC_LGUI, LALT_T(KC_BSPC), KC_LSFT, EXIT_RAND, RAISE, KC_SPC, RCTL_T(KC_DEL), DM_REC2, DM_PLY2, DM_RSTP
+    RAND_0,  RAND_1,  RAND_2,  RAND_3,  RAND_4,  RAND_5,  RAND_6,  RAND_7,  RAND_8,  RAND_9,  RAND_10, RAND_11,
+    RAND_12, RAND_13, RAND_14, RAND_15, RAND_16, RAND_17, RAND_18, RAND_19, RAND_20, RAND_21, RAND_22, RAND_23,
+    RAND_24, RAND_25, RAND_26, RAND_27, RAND_28, RAND_29, RAND_30, RAND_31, RAND_32, RAND_33, RAND_34, RAND_35,
+    RAND_36, RAND_37, RAND_38, RAND_39, RAND_40, RAND_41, RAND,    RAND_42, RAND_43, RAND_44, RAND_45, RAND_46
 )
 
 };
 
+const int RAND_LEN = 1 + RAND_46 - RAND_0;
+
+uint16_t PROGMEM rand_keymap[RAND_LEN] = {
+    KC_TAB,  KC_Q,    KC_W,    KC_E,            KC_R,    KC_T,   KC_Y,  KC_U,   KC_I,           KC_O,    KC_P,    KC_BSPC,
+    KC_ESC,  KC_A,    KC_S,    KC_D,            KC_F,    KC_G,   KC_H,  KC_J,   KC_K,           KC_L,    KC_SCLN, QUOTE,
+    KC_LEFT, KC_Z,    KC_X,    KC_C,            KC_V,    KC_B,   KC_N,  KC_M,   KC_COMM,        KC_DOT,  KC_SLSH, KC_RGHT,
+    DM_REC1, DM_PLY1, KC_LGUI, LALT_T(KC_BSPC), KC_LSFT,         RAISE, KC_SPC, RCTL_T(KC_DEL), DM_REC2, DM_PLY2, DM_RSTP
+}
+
 bool random_initialized = false;
 
 void shuffle_rand_layout(void) {
-    for (int i = 0; i < MATRIX_ROWS; i++) {
-        for (int j = 0; j < MATRIX_COLS; j++) {
-            int swap_i = rand() % MATRIX_ROWS;
-            int swap_j = rand() % MATRIX_COLS;
+    for (int i = 0; i < RAND_LEN; i++) {
+        const int swap_i = rand() % RAND_LEN;
 
-            uint16_t swap_val = keymaps[_RAND][i][j];
-            keymaps[_RAND][i][j] = keymaps[_RAND][swap_i][swap_j];
-            keymaps[_RAND][swap_i][swap_j] = swap_val;
-        }
+        const uint16_t swap_val = rand_keymap[i];
+        rand_keymap[i] = rand_keymap[swap_i];
+        rand_keymap[swap_i] = swap_val;
     }
 }
 
@@ -71,6 +123,27 @@ void shuffle_rand_layout(void) {
 #endif
 
 bool process_record_user(uint16_t keycode, keyrecord_t *record) {
+    #ifdef RAND_ENABLE
+    if (keycode >= RAND_0 && keycode <= RAND_46) {
+        const int rand_index = keycode - RAND_0;
+        const uint16_t new_keycode = rand_keymap[rand_index];
+
+        if (new_keycode >= RAND && new_keycode <= SIGN) {
+            // This is an existing keycode, so let the rest of the function handle it.
+            keycode = new_keycode;
+        }
+        else {
+            // An existing keycode, so fine to treat it like normal basically.
+            if (record->event.pressed) {
+                register_code16(new_keycode);
+            } else {
+                unregister_code16(new_keycode);
+            }
+            return false;
+        }
+    }
+    #endif
+
     const uint8_t mod_state = get_mods();
     uint16_t custom_keycode;
     switch (keycode) {
@@ -81,18 +154,14 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
             random_initialized = true;
         }
 
-        if (!record->event.pressed) {
+        if (!record->event.pressed && !(mod_state & MOD_MASK_SHIFT)) {
             #ifdef AUDIO_ENABLE
                 PLAY_SONG(plover_song);
             #endif
             shuffle_rand_layout();
             layer_on(_RAND);
         }
-        #endif
-        return false;
-    case EXIT_RAND: ;
-        #ifdef RAND_ENABLE
-        if (record->event.pressed) {
+        else if (record->event.pressed && (mod_state & MOD_MASK_SHIFT)) {
             #ifdef AUDIO_ENABLE
                 PLAY_SONG(plover_gb_song);
             #endif

--- a/rules.mk
+++ b/rules.mk
@@ -33,3 +33,7 @@ BLUETOOTH_ENABLE = no
 RGBLIGHT_ENABLE = no
 # Do not enable SLEEP_LED_ENABLE. it uses the same timer as BACKLIGHT_ENABLE
 SLEEP_LED_ENABLE = no
+
+ifeq ($(strip $(RAND_ENABLE)), yes)
+    RAND_ENABLE += -DRAND_ENABLE
+endif


### PR DESCRIPTION
- Fixes the compiler warning about the void function signature.
- Add the plumbing so the random feature can be easily enabled/disabled.
- Allows keymaps array to be const, so the qmk source doesn't need to be modified to make it work.
- Prevents the rand (de)activation key from being randomized.
- Rand layer deactivation is now shift+rand.